### PR TITLE
Bugfix - Fixing path for @rangle/react-scripts when ejecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ Put this same configuration inside `jest-config.json` in the root folder, but no
   }
 }
 ```
+
+### Ejecting and `jest-config.json`
+
+Note that when ejecting `jest-config.json` will be wiped out and its content with be added, along with the standard jest configuration, into the new generated `package.json`. 

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rangle/react-scripts",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "description": "Rangle's custom configuration and scripts for Create React App.",
   "repository": "rangle/create-react-app",
   "license": "BSD-3-Clause",

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -29,7 +29,9 @@ prompt(
   console.log('Ejecting...');
 
   var ownPath = path.join(__dirname, '..');
-  var appPath = path.join(ownPath, '..', '..');
+  // Rangle's NPM org adds a folder between react-scripts and node_modules
+  // so we have to go one folder up than the default
+  var appPath = path.join(ownPath, '..', '..', '..');
 
   function verifyAbsent(file) {
     if (fs.existsSync(path.join(appPath, file))) {
@@ -46,6 +48,7 @@ prompt(
   var folders = [
     'config',
     path.join('config', 'jest'),
+    path.join('config', 'rangle'),
     'scripts'
   ];
 
@@ -57,6 +60,8 @@ prompt(
     path.join('config', 'webpack.config.prod.js'),
     path.join('config', 'jest', 'cssTransform.js'),
     path.join('config', 'jest', 'fileTransform.js'),
+    path.join('config', 'rangle', 'plugins.js'),
+    path.join('config', 'rangle', 'postcss.js'),
     path.join('scripts', 'build.js'),
     path.join('scripts', 'start.js'),
     path.join('scripts', 'test.js')
@@ -142,6 +147,11 @@ prompt(
     JSON.stringify(appPackage, null, 2)
   );
   console.log();
+
+  if (fs.existsSync(paths.testsCustomConfig)) {
+    console.log(cyan('Removing custom jest-config.json...'));
+    fs.removeSync(paths.testsCustomConfig);
+  }
 
   if (fs.existsSync(paths.yarnLockFile)) {
     console.log(cyan('Running yarn...'));


### PR DESCRIPTION
Rangle's NPM org adds a folder between react-scripts and node_modules, which makes the relative path fail when ejecting.